### PR TITLE
Added compiler version number for VS 16.4.4

### DIFF
--- a/_posts/2019-12-09-vs-2019-update-4.md
+++ b/_posts/2019-12-09-vs-2019-update-4.md
@@ -24,6 +24,7 @@ The C/C++ Runtime (14.24.28127) is included in this update. Remember that VS 201
 --|--
 16.4.0 | 19.24.28314.0
 16.4.3 | 19.24.28315.0
+16.4.4 | 19.24.28316.0
 
 > Note that the Visual C/C++ Runtime library is now available on [GitHub](https://github.com/microsoft/STL). See [this blog post](https://devblogs.microsoft.com/cppblog/open-sourcing-msvcs-stl/) for more information.
 


### PR DESCRIPTION
There are a number of (older) build numbers I could not attach to a precise Visual Studio build... Is there an authoritative source somewhere beside your blog?